### PR TITLE
Initial data sharing platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# gitskills
+# Data Exchange Sharing Platform
+
+This repository contains a simple data exchange platform. It has a minimal
+backend written with Node's built-in modules and a frontend built with plain
+HTML, CSS and JavaScript.
+
+## Running
+
+Run the server with:
+
+```bash
+node server.js
+```
+
+The application will be available at `http://localhost:3000`.
+
+## Project Structure
+
+- `server.js` - simple HTTP server that exposes `/api/data` and serves files in
+  `public`.
+- `data/data.json` - sample JSON data returned by the API.
+- `public/` - frontend files (HTML/CSS/JS).
+

--- a/data/data.json
+++ b/data/data.json
@@ -1,0 +1,5 @@
+[
+  {"id": 1, "name": "Item 1", "description": "First item"},
+  {"id": 2, "name": "Item 2", "description": "Second item"},
+  {"id": 3, "name": "Item 3", "description": "Third item"}
+]

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Not Found</title>
+</head>
+<body>
+  <h1>404 - Not Found</h1>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Data Exchange Platform</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Data Exchange Platform</h1>
+  <div id="data-container"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,16 @@
+async function loadData() {
+  try {
+    const response = await fetch('/api/data');
+    const data = await response.json();
+    const container = document.getElementById('data-container');
+    data.forEach(item => {
+      const div = document.createElement('div');
+      div.className = 'item';
+      div.innerHTML = `<h3>${item.name}</h3><p>${item.description}</p>`;
+      container.appendChild(div);
+    });
+  } catch (err) {
+    console.error('Error loading data', err);
+  }
+}
+window.onload = loadData;

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,12 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+#data-container {
+  margin-top: 20px;
+}
+.item {
+  border: 1px solid #ccc;
+  padding: 10px;
+  margin-bottom: 10px;
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,49 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = process.env.PORT || 3000;
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/api/data') {
+    fs.readFile(path.join(__dirname, 'data', 'data.json'), 'utf8', (err, data) => {
+      if (err) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Internal Server Error' }));
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(data);
+    });
+    return;
+  }
+
+  const filePath = path.join(__dirname, 'public', req.url === '/' ? 'index.html' : req.url);
+  const ext = path.extname(filePath).toLowerCase();
+  const mimeTypes = {
+    '.html': 'text/html',
+    '.js': 'application/javascript',
+    '.css': 'text/css',
+    '.json': 'application/json',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.svg': 'image/svg+xml'
+  };
+
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      fs.readFile(path.join(__dirname, 'public', '404.html'), (err404, content404) => {
+        res.writeHead(err404 ? 404 : 200, { 'Content-Type': 'text/html' });
+        res.end(content404 || '404 Not Found');
+      });
+    } else {
+      res.writeHead(200, { 'Content-Type': mimeTypes[ext] || 'text/plain' });
+      res.end(content);
+    }
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- implement Node-based backend server to serve static files and a `/api/data` endpoint
- add example JSON data
- create basic frontend (HTML/CSS/JS) to display data
- update README with instructions

## Testing
- `node server.js` *(manual server start)*
- `curl http://localhost:3000/api/data`

------
https://chatgpt.com/codex/tasks/task_e_683a62fe98948326ad1f332eefef78f7